### PR TITLE
Add reviews command to capture PRs reviewed by a user

### DIFF
--- a/graph_test.go
+++ b/graph_test.go
@@ -26,7 +26,7 @@ func TestHandleGraphCommand_Basic(t *testing.T) {
 	week3Date := fixedOneMonthAgo.AddDate(0, 0, 17) // 17 days after since date (Week 3)
 
 	mockClient.GetFunc = func(path string, response interface{}) error {
-		if strings.Contains(path, "is%3Apr") {
+		if strings.Contains(path, "is%3Apr") && strings.Contains(path, "author%3A") {
 			// PR response
 			resp := GitHubResponse{
 				TotalCount: 3,
@@ -57,6 +57,11 @@ func TestHandleGraphCommand_Basic(t *testing.T) {
 					},
 				},
 			}
+			data, _ := json.Marshal(resp)
+			return json.Unmarshal(data, response)
+		} else if strings.Contains(path, "is%3Apr") && strings.Contains(path, "reviewed-by%3A") {
+			// Reviews response - empty
+			resp := GitHubResponse{TotalCount: 0, Items: []GitHubItem{}}
 			data, _ := json.Marshal(resp)
 			return json.Unmarshal(data, response)
 		} else if strings.Contains(path, "is%3Aissue") {
@@ -127,8 +132,8 @@ func TestHandleGraphCommand_Basic(t *testing.T) {
 	}
 
 	// Check API calls
-	if len(mockClient.GetCalls) != 2 {
-		t.Errorf("Expected 2 API calls (PRs + Issues), got %d", len(mockClient.GetCalls))
+	if len(mockClient.GetCalls) != 3 {
+		t.Errorf("Expected 3 API calls (PRs + Reviews + Issues), got %d", len(mockClient.GetCalls))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -169,8 +169,10 @@ const (
 	startOfEntry   = "---START-OF-ENTRY---"
 	startOfPR      = "---START-OF-PR---"
 	startOfIssue   = "---START-OF-ISSUE---"
+	startOfReview  = "---START-OF-REVIEW---"
 	endOfPR        = "---END-OF-PR---"
 	endOfIssue     = "---END-OF-ISSUE---"
+	endOfReview    = "---END-OF-REVIEW---"
 
 	systemPrompt = `You are an expert engineering manager assistant designed to
 	summarize the bodies of GitHub issues and pull requests. Your goal is to
@@ -329,6 +331,8 @@ func main() {
 	switch cmd {
 	case "pulls":
 		handlePullsCommand(subcommandArgs, ghClient)
+	case "reviews":
+		handleReviewsCommand(subcommandArgs, ghClient)
 	case "issues":
 		handleIssuesCommand(subcommandArgs, ghClient)
 	case "all":
@@ -376,6 +380,45 @@ func handlePullsCommand(args []string, client GitHubClient) {
 
 	if bodyOnly {
 		printBodies(responseItems, startOfPR, endOfPR)
+		return
+	}
+
+	printPullRequestsAsCSV(responseItems)
+}
+
+func handleReviewsCommand(args []string, client GitHubClient) {
+	if len(args) < 2 {
+		fmt.Println("Error: login argument is required")
+		fmt.Println("Usage: gh-contrib reviews <login>")
+		return
+	}
+	login := args[1]
+
+	org, err := orgConfigFunc()
+	if err != nil {
+		org = defaultOrg
+	}
+
+	query := buildReviewQuery(login)
+	searchURL := fmt.Sprintf("search/issues?q=%s", query)
+
+	if debug {
+		fmt.Printf("Calling GitHub API with URL: %s\n", searchURL)
+	}
+
+	responseItems, err := fetchAllResults(client, searchURL)
+	if err != nil {
+		fmt.Println("Error fetching reviews:", err)
+		return
+	}
+
+	if len(responseItems) == 0 {
+		fmt.Printf("No reviewed pull requests found for user '%s' in the '%s' organization.\n", login, org)
+		return
+	}
+
+	if bodyOnly {
+		printBodies(responseItems, startOfReview, endOfReview)
 		return
 	}
 
@@ -441,6 +484,21 @@ func handleAllCommand(args []string, client GitHubClient) {
 		return
 	}
 
+	reviewQuery := buildReviewQuery(login)
+	reviewSearchURL := fmt.Sprintf("search/issues?q=%s", reviewQuery)
+	if debug {
+		fmt.Printf("Calling GitHub API for reviews with URL: %s\n", reviewSearchURL)
+	}
+
+	reviewItems, err := fetchAllResults(client, reviewSearchURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching reviews: %v\n", err)
+		return
+	}
+
+	// Deduplicate: remove reviews that the user also authored (already in prItems)
+	reviewItems = deduplicateItems(prItems, reviewItems)
+
 	issueQuery := buildQuery("is:issue", login)
 	issueSearchURL := fmt.Sprintf("search/issues?q=%s", issueQuery)
 	if debug {
@@ -456,6 +514,7 @@ func handleAllCommand(args []string, client GitHubClient) {
 	if bodyOnly {
 
 		printBodies(prItems, startOfPR, endOfPR)
+		printBodies(reviewItems, startOfReview, endOfReview)
 		printBodies(issueItems, startOfIssue, endOfIssue)
 		return
 	}
@@ -473,6 +532,16 @@ func handleAllCommand(args []string, client GitHubClient) {
 			pr.HTMLURL + " ",
 			pr.Title,
 			pr.State,
+		})
+	}
+
+	// Write reviews
+	for _, review := range reviewItems {
+		writer.Write([]string{
+			"Review",
+			review.HTMLURL + " ",
+			review.Title,
+			review.State,
 		})
 	}
 
@@ -555,6 +624,24 @@ func handleGraphCommand(args []string, client GitHubClient) {
 		return
 	}
 
+	// Build the query for Reviews within the time range
+	reviewQuery := buildReviewQuery(login)
+	reviewSearchURL := fmt.Sprintf("search/issues?q=%s", reviewQuery)
+
+	if debug {
+		fmt.Printf("Calling GitHub API for Reviews with URL: %s\n", reviewSearchURL)
+	}
+
+	// Fetch all Reviews
+	reviewItems, err := fetchAllResults(client, reviewSearchURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching reviews for graph: %v\n", err)
+		return
+	}
+
+	// Deduplicate: remove reviews that the user also authored
+	reviewItems = deduplicateItems(prItems, reviewItems)
+
 	// Build the query for Issues within the time range
 	issueQuery := buildQuery("is:issue", login)
 	issueSearchURL := fmt.Sprintf("search/issues?q=%s", issueQuery)
@@ -571,7 +658,7 @@ func handleGraphCommand(args []string, client GitHubClient) {
 	}
 
 	// Check if there are any results to display
-	if len(prItems) == 0 && len(issueItems) == 0 {
+	if len(prItems) == 0 && len(reviewItems) == 0 && len(issueItems) == 0 {
 		fmt.Printf("No contributions found for user '%s' in the '%s' organization since %s.\n", login, org, since)
 		return
 	}
@@ -586,7 +673,7 @@ func handleGraphCommand(args []string, client GitHubClient) {
 	daysActive := int(today.Sub(sinceDate).Hours()/24) + 1
 
 	// Combined count of all contributions
-	totalContributions := len(prItems) + len(issueItems)
+	totalContributions := len(prItems) + len(reviewItems) + len(issueItems)
 	averageContributions := float64(totalContributions) / float64(daysActive)
 
 	// Group contributions by week
@@ -613,6 +700,8 @@ func handleGraphCommand(args []string, client GitHubClient) {
 
 	// Process PRs
 	processItems(prItems, sinceDate, weekMap, weekStartDates)
+	// Process Reviews
+	processItems(reviewItems, sinceDate, weekMap, weekStartDates)
 	// Process Issues
 	processItems(issueItems, sinceDate, weekMap, weekStartDates)
 
@@ -635,12 +724,16 @@ func handleGraphCommand(args []string, client GitHubClient) {
 
 	// Count PRs by state for each week
 	countItemsByWeek(prItems, "pr", sinceDate, weekContributionMap)
+	// Count Reviews by state for each week
+	countItemsByWeek(reviewItems, "review", sinceDate, weekContributionMap)
 	// Count Issues by state for each week
 	countItemsByWeek(issueItems, "issue", sinceDate, weekContributionMap)
 
 	// Track counts for summary
 	closedPRs := 0
 	openPRs := 0
+	closedReviews := 0
+	openReviews := 0
 	closedIssues := 0
 	openIssues := 0
 
@@ -648,12 +741,16 @@ func handleGraphCommand(args []string, client GitHubClient) {
 	for _, week := range weeks {
 		closedPR := weekContributionMap[week][contributionType{"pr", "closed"}]
 		openPR := weekContributionMap[week][contributionType{"pr", "open"}]
+		closedReview := weekContributionMap[week][contributionType{"review", "closed"}]
+		openReview := weekContributionMap[week][contributionType{"review", "open"}]
 		closedIssue := weekContributionMap[week][contributionType{"issue", "closed"}]
 		openIssue := weekContributionMap[week][contributionType{"issue", "open"}]
 
 		// Update summary counts
 		closedPRs += closedPR
 		openPRs += openPR
+		closedReviews += closedReview
+		openReviews += openReview
 		closedIssues += closedIssue
 		openIssues += openIssue
 
@@ -667,6 +764,16 @@ func handleGraphCommand(args []string, client GitHubClient) {
 		// Print open PRs with ○ symbol
 		for i := 0; i < openPR; i++ {
 			fmt.Print("○")
+		}
+
+		// Print closed reviews with ◆ symbol
+		for i := 0; i < closedReview; i++ {
+			fmt.Print("◆")
+		}
+
+		// Print open reviews with ◇ symbol
+		for i := 0; i < openReview; i++ {
+			fmt.Print("◇")
 		}
 
 		// Print closed issues with ■ symbol
@@ -698,6 +805,16 @@ func handleGraphCommand(args []string, client GitHubClient) {
 		}
 	}
 
+	// Only include Review symbols in the legend if we have Reviews
+	if len(reviewItems) > 0 {
+		if closedReviews > 0 {
+			legendParts = append(legendParts, "◆ = Closed Review")
+		}
+		if openReviews > 0 {
+			legendParts = append(legendParts, "◇ = Open Review")
+		}
+	}
+
 	// Only include Issue symbols in the legend if we have Issues
 	if len(issueItems) > 0 {
 		if closedIssues > 0 {
@@ -719,6 +836,9 @@ func handleGraphCommand(args []string, client GitHubClient) {
 
 	fmt.Printf("PRs: %d total (%d closed, %d open)\n",
 		len(prItems), closedPRs, openPRs)
+
+	fmt.Printf("Reviews: %d total (%d closed, %d open)\n",
+		len(reviewItems), closedReviews, openReviews)
 
 	fmt.Printf("Issues: %d total (%d closed, %d open)\n",
 		len(issueItems), closedIssues, openIssues)
@@ -793,6 +913,16 @@ func buildQuery(itemType, login string) string {
 	return query
 }
 
+func buildReviewQuery(login string) string {
+	org := getEffectiveOrg()
+	query := fmt.Sprintf("is:pr org:%s reviewed-by:%s sort:created-desc", org, login)
+	if since != "" {
+		query += fmt.Sprintf(" created:>%s", since)
+		query = url.QueryEscape(query)
+	}
+	return query
+}
+
 // buildWebURL constructs a GitHub web URL for the given query
 func buildWebURL(itemType, login string) string {
 	org := getEffectiveOrg()
@@ -810,6 +940,21 @@ func buildWebURL(itemType, login string) string {
 	// URL encode the query for the web interface
 	encodedQuery := url.QueryEscape(query)
 	return fmt.Sprintf("https://github.com/issues?q=%s", encodedQuery)
+}
+
+// deduplicateItems removes items from candidates that already appear in existing (by HTMLURL).
+func deduplicateItems(existing, candidates []GitHubItem) []GitHubItem {
+	seen := make(map[string]bool, len(existing))
+	for _, item := range existing {
+		seen[item.HTMLURL] = true
+	}
+	var result []GitHubItem
+	for _, item := range candidates {
+		if !seen[item.HTMLURL] {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 func fetchAllResults(client GitHubClient, searchURL string) ([]GitHubItem, error) {
@@ -870,8 +1015,9 @@ func printHelp(client GitHubClient) {
 	printUserInfo(client)
 	fmt.Println("\nAvailable commands:")
 	fmt.Println("  pulls <username>   - Get Pull Requests authored by <username> in the 'github' (or specified) org.")
+	fmt.Println("  reviews <username> - Get Pull Requests reviewed by <username> in the 'github' (or specified) org.")
 	fmt.Println("  issues <username>  - Get Issues authored by <username> in the 'github' (or specified) org.")
-	fmt.Println("  all <username>     - Get all Pull Requests and Issues by <username> in the 'github' (or specified) org.")
+	fmt.Println("  all <username>     - Get all Pull Requests, Reviews, and Issues by <username> in the 'github' (or specified) org.")
 	fmt.Println("  summarize          - Summarize PR/Issue bodies from stdin or argument.")
 	fmt.Println("  graph <username>   - Graph visualization for contributions by <username>.")
 	fmt.Println("\nFlags:")

--- a/main_test.go
+++ b/main_test.go
@@ -242,6 +242,12 @@ func TestHandleAllCommand_CSV(t *testing.T) {
 					Name string `json:"name"`
 				}{"test-repo"}},
 			}
+		} else if strings.Contains(path, "search/issues?q=") && strings.Contains(path, "is%3Apr") && strings.Contains(path, "reviewed-by%3Atestuser") && strings.Contains(path, "page=1") {
+			items = []GitHubItem{
+				{Number: 789, Title: "Reviewed PR", HTMLURL: "http://example.com/pr/789", State: "closed", Repository: struct {
+					Name string `json:"name"`
+				}{"review-repo"}},
+			}
 		} else if strings.Contains(path, "search/issues?q=") && strings.Contains(path, "is%3Aissue") && strings.Contains(path, "author%3Atestuser") && strings.Contains(path, "page=1") {
 			items = []GitHubItem{
 				{Number: 456, Title: "Test Issue", HTMLURL: "http://example.com/issue/456", State: "closed", Repository: struct {
@@ -267,6 +273,7 @@ func TestHandleAllCommand_CSV(t *testing.T) {
 
 	expectedHeader := "Type,URL,Title,State"
 	expectedPRRow := "Pull Request,http://example.com/pr/123 ,Test PR,open"
+	expectedReviewRow := "Review,http://example.com/pr/789 ,Reviewed PR,closed"
 	expectedIssueRow := "Issue,http://example.com/issue/456 ,Test Issue,closed"
 
 	if !strings.Contains(stdout, expectedHeader) {
@@ -275,11 +282,134 @@ func TestHandleAllCommand_CSV(t *testing.T) {
 	if !strings.Contains(stdout, expectedPRRow) {
 		t.Errorf("Expected stdout to contain PR row '%s', got: %s", expectedPRRow, stdout)
 	}
+	if !strings.Contains(stdout, expectedReviewRow) {
+		t.Errorf("Expected stdout to contain Review row '%s', got: %s", expectedReviewRow, stdout)
+	}
 	if !strings.Contains(stdout, expectedIssueRow) {
 		t.Errorf("Expected stdout to contain Issue row '%s', got: %s", expectedIssueRow, stdout)
 	}
-	if len(mockClient.GetCalls) != 2 { // One for PRs, one for Issues
-		t.Errorf("Expected 2 API calls, got %d", len(mockClient.GetCalls))
+	if len(mockClient.GetCalls) != 3 { // One for PRs, one for Reviews, one for Issues
+		t.Errorf("Expected 3 API calls, got %d", len(mockClient.GetCalls))
+	}
+}
+
+func TestHandleReviewsCommand_CSV(t *testing.T) {
+	resetFlags()
+	mockClient := &MockGitHubClient{}
+	testLogin := "testuser"
+	testArgs := []string{"reviews", testLogin}
+
+	mockClient.GetFunc = func(path string, response interface{}) error {
+		if strings.Contains(path, "search/issues?q=") && strings.Contains(path, "is%3Apr") && strings.Contains(path, "reviewed-by%3Atestuser") && strings.Contains(path, "page=1") {
+			resp := GitHubResponse{
+				TotalCount: 1,
+				Items: []GitHubItem{
+					{Number: 789, Title: "Reviewed PR", HTMLURL: "http://example.com/pr/789", State: "closed", Repository: struct {
+						Name string `json:"name"`
+					}{"review-repo"}},
+				},
+			}
+			data, _ := json.Marshal(resp)
+			return json.Unmarshal(data, response)
+		}
+		return fmt.Errorf("unexpected API call: %s", path)
+	}
+
+	stdout, stderr := captureOutput(func() {
+		handleReviewsCommand(testArgs, mockClient)
+	})
+
+	if stderr != "" {
+		t.Errorf("Expected no stderr, got: %s", stderr)
+	}
+
+	expectedHeader := "URL,Title,State"
+	expectedRow := "http://example.com/pr/789 ,Reviewed PR,closed"
+
+	if !strings.Contains(stdout, expectedHeader) {
+		t.Errorf("Expected stdout to contain header '%s', got: %s", expectedHeader, stdout)
+	}
+	if !strings.Contains(stdout, expectedRow) {
+		t.Errorf("Expected stdout to contain row '%s', got: %s", expectedRow, stdout)
+	}
+	if len(mockClient.GetCalls) != 1 {
+		t.Errorf("Expected 1 API call, got %d", len(mockClient.GetCalls))
+	}
+}
+
+func TestHandleReviewsCommand_BodyOnly(t *testing.T) {
+	resetFlags()
+	bodyOnly = true
+	mockClient := &MockGitHubClient{}
+	testLogin := "testuser"
+	testArgs := []string{"reviews", testLogin}
+
+	mockClient.GetFunc = func(path string, response interface{}) error {
+		if strings.Contains(path, "search/issues?q=") && strings.Contains(path, "is%3Apr") && strings.Contains(path, "reviewed-by%3Atestuser") && strings.Contains(path, "page=1") {
+			resp := GitHubResponse{
+				TotalCount: 1,
+				Items: []GitHubItem{
+					{Number: 789, Title: "Reviewed PR", Body: "Review body.", HTMLURL: "http://example.com/pr/789", State: "closed", Repository: struct {
+						Name string `json:"name"`
+					}{"review-repo"}},
+				},
+			}
+			data, _ := json.Marshal(resp)
+			return json.Unmarshal(data, response)
+		}
+		return fmt.Errorf("unexpected API call: %s", path)
+	}
+
+	stdout, stderr := captureOutput(func() {
+		handleReviewsCommand(testArgs, mockClient)
+	})
+
+	if stderr != "" {
+		t.Errorf("Expected no stderr, got: %s", stderr)
+	}
+
+	expectedOutput := fmt.Sprintf("%s\n%s #%d\n%s\n%s\n%s\n", startOfReview, "Reviewed PR", 789, "Review body.", endOfReview, entryDelimiter)
+
+	if stdout != expectedOutput {
+		t.Errorf("Expected stdout to be:\n%s\nGot:\n%s", expectedOutput, stdout)
+	}
+}
+
+func TestBuildReviewQuery(t *testing.T) {
+	resetFlags()
+	testLogin := "testuser"
+
+	originalOrgConfigFunc := orgConfigFunc
+	orgConfigFunc = func() (string, error) {
+		return "github", nil
+	}
+	defer func() { orgConfigFunc = originalOrgConfigFunc }()
+
+	since = "2025-01-15"
+	expected := "is%3Apr+org%3Agithub+reviewed-by%3Atestuser+sort%3Acreated-desc+created%3A%3E2025-01-15"
+	actual := buildReviewQuery(testLogin)
+	if actual != expected {
+		t.Errorf("Expected query '%s', got '%s'", expected, actual)
+	}
+}
+
+func TestDeduplicateItems(t *testing.T) {
+	existing := []GitHubItem{
+		{HTMLURL: "http://example.com/pr/1"},
+		{HTMLURL: "http://example.com/pr/2"},
+	}
+	candidates := []GitHubItem{
+		{HTMLURL: "http://example.com/pr/2", Title: "Duplicate"},
+		{HTMLURL: "http://example.com/pr/3", Title: "Unique"},
+	}
+
+	result := deduplicateItems(existing, candidates)
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 item after dedup, got %d", len(result))
+	}
+	if result[0].HTMLURL != "http://example.com/pr/3" {
+		t.Errorf("Expected unique item, got %s", result[0].HTMLURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new `reviews <username>` command that fetches PRs reviewed by the specified user using the `reviewed-by:` search qualifier. Reviews are also included in the `all` and `graph` commands.

This addresses one of the key gaps in `gh-contrib` — previously it only captured **authored** PRs and issues, missing the important signal of code review activity.

## Changes

### New `reviews` command
- `gh contrib reviews <username>` — fetches PRs reviewed by the user
- Uses `reviewed-by:<user>` qualifier on the existing `search/issues` API
- Supports `--body-only`, `--since`, `--org` flags (same as `pulls`)

### Updated `all` command
- Now includes reviews as a `Review` type row in CSV output
- Deduplicates: if a user both authored and reviewed a PR, it only appears once (as "Pull Request")

### Updated `graph` command
- Reviews appear with `◆` (closed) and `◇` (open) symbols
- Legend and summary updated to include review counts
- Same deduplication logic

### New helper
- `deduplicateItems()` — removes items from review results that already appear in authored PR results (matched by URL)

## Testing

- `TestHandleReviewsCommand_CSV` — verifies CSV output for reviews
- `TestHandleReviewsCommand_BodyOnly` — verifies body-only output with review markers
- `TestBuildReviewQuery` — verifies the `reviewed-by:` query construction
- `TestDeduplicateItems` — verifies dedup logic
- Updated `TestHandleAllCommand_CSV` to expect reviews in output
- Updated `TestHandleGraphCommand_Basic` to expect 3 API calls

All 24 tests pass.

Closes #10 (partially — discussions support tracked separately)